### PR TITLE
meta data added for single state route

### DIFF
--- a/routes/stats-routes.js
+++ b/routes/stats-routes.js
@@ -10,7 +10,7 @@ statsRouter.get('/', covidDataHelpers.getUSTotals, covidDataHelpers.getStateTota
 })
 
 //GET /stats/:id - return selected State Data - two letter state code required (ex: GA, CA)
-statsRouter.get('/:id', covidDataHelpers.getSingleStateDetails, covidDataHelpers.getSingleStateHistoricals, (req, res) => {
+statsRouter.get('/:id', covidDataHelpers.getSingleStateDetails, covidDataHelpers.getSingleStateHistoricals, covidDataHelpers.getSingleStateMeta, (req, res) => {
     res.json(res.locals)
 })
 

--- a/services/covid-data-helpers.js
+++ b/services/covid-data-helpers.js
@@ -104,6 +104,21 @@ const getSingleStateHistoricals = (req, res, next) => {
 
 }
 
+const getSingleStateMeta = (req, res, next) => {
+    fetch(`https://api.covidtracking.com/v1/states/ca/info.json`)
+    .then((res) => res.json())
+    .then((data) => {
+        let covidData = data;
+        res.locals.singleStateMeta = covidData;
+        next();
+    })
+    .catch((err) => {
+        console.log(err);
+        next(err);
+    })
+
+}
+
 const getHistoricalDetails = (req, res, next) => {
     UserStates.getDistinctStatesByUser(req.user.id)
     .then((userStates) => {
@@ -138,6 +153,7 @@ module.exports = {
     getStateTotals,
     getSingleStateDetails,
     getSingleStateHistoricals,
+    getSingleStateMeta,
     getCountryHistoricals,
     getHistoricalDetails
 }


### PR DESCRIPTION
- pulling in state metadata on covid-helpers
- added to `/stats/:id` route

Tested in postman and saw the data coming through as expected!