### PR TITLE
missed redirects not including /api

### DIFF
--- a/routes/auth-routes.js
+++ b/routes/auth-routes.js
@@ -7,8 +7,8 @@ const usersController = require('../controllers/users-controller')
 //POST /auth/login - User submits login form.
 //Passport authenticates the user for us based on the 'local' strategy in services/auth/local.js
 authRouter.post('/login', authHelpers.loginRedirect, passport.authenticate('local', {
-    successRedirect: '/auth/login',
-    failureRedirect: '/auth/login',
+    successRedirect: '/api/auth/login',
+    failureRedirect: '/api/auth/login',
     failureFlash: true,
 }))
 


### PR DESCRIPTION
- missed a few routes in auth direct that still needed `/api` in them